### PR TITLE
stb_image requires the math library

### DIFF
--- a/libs/stb/stb_image.nelua
+++ b/libs/stb/stb_image.nelua
@@ -2,6 +2,7 @@
 if not STB_IMAGE_NO_IMPL then
   cdefine 'STB_IMAGE_STATIC'
   cdefine 'STB_IMAGE_IMPLEMENTATION'
+  linklib 'm'
 end
 if not ccinfo.is_gcc then
   cdefine 'STBI_NO_SIMD'


### PR DESCRIPTION
Just simply added "linklib 'm'" at line 5.
Without it would throw a link time error.